### PR TITLE
JQ Dependency check/install and GPS change from Ruby to Python

### DIFF
--- a/getardoplist
+++ b/getardoplist
@@ -23,6 +23,28 @@ MYVARA=$HOME/patmenu2/vara-list/
 #my log file
 LOG=$HOME/Documents/mylog.txt
 
+JQ_INSTALLED=$(which jq)
+
+if [ -z "$JQ_INSTALLED" ]; then
+yad --form --width=300 --text-align=center --center --title="JQ not Found" --text-align=center \
+--image $LOGO --window-icon=$LOGO --image-on-top --separator="|" --item-separator="|" \
+--text="JQ is needed to parse grid location but not found installed on your system. Would you like to install it now?" \
+--button="Install JQ":2 \
+--button="Cancel":1
+BUT=$?
+	if [ $BUT = 1 ]; then
+	$MAIN &
+	exit
+	elif [ $BUT = 2 ]; then
+	INSTALLJQ(){
+	sudo apt-get update
+	sudo apt-get install -y jq
+	}
+	INSTALLJQ | yad --center --progress --pulsate --auto-close --no-buttons --text-align=center \
+--text="Installing JQ. This will take several minutes\r<b>DO NOT CLOSE THIS WINDOW</b>\rDoing so will abort the install."
+	fi
+fi
+
 GRIDCK=$(jq .locator $HOME/.config/pat/config.json)
 if [ ${#GRIDCK} -lt 3 ]
 then

--- a/getgrid.py
+++ b/getgrid.py
@@ -1,0 +1,30 @@
+#! /usr/bin/env python3
+
+import gps               # the gpsd interface module
+import maidenhead as mh  # maidenhead library to convert lat/long
+
+session = gps.gps(mode=gps.WATCH_ENABLE)
+
+try:
+    while 0 == session.read():
+        if not (gps.MODE_SET & session.valid):
+            # not useful, probably not a TPV message
+            continue
+
+        if ((gps.isfinite(session.fix.latitude) and
+             gps.isfinite(session.fix.longitude))):
+            level=4
+            print (mh.to_maiden(session.fix.latitude, 
+                    session.fix.longitude, level))
+            break
+        else:
+            print("NOFIX")
+            break
+
+except KeyboardInterrupt:
+    # got a ^C.  Say bye, bye
+    print('')
+
+# Got ^C, or fell out of the loop.  Cleanup, and leave.
+session.close()
+exit(0)

--- a/manage-pat-functions
+++ b/manage-pat-functions
@@ -135,7 +135,7 @@ BUT=$?
 	elif [ $BUT = 2 ]; then
 	INSTALLRUBY(){
 	sudo -A apt-get update
-	sudo -A apt-get install -y ruby2.7
+	sudo -A apt-get install -y ruby3
 	sudo -A gem install gpsd_client
 	sudo -A gem install maidenhead
 	}

--- a/manage-pat-functions
+++ b/manage-pat-functions
@@ -121,7 +121,7 @@ fi
 GPSGRID(){
 CONFIG=$HOME/.config/pat/config.json
 
-if ! hash ruby2.3 2>/dev/null; then
+if ! hash ruby>/dev/null; then
 echo "Ruby Not found on system"
 yad --form --width=300 --text-align=center --center --title="Ruby not Found" --text-align=center \
 --image $LOGO --window-icon=$LOGO --image-on-top --separator="|" --item-separator="|" \
@@ -135,7 +135,7 @@ BUT=$?
 	elif [ $BUT = 2 ]; then
 	INSTALLRUBY(){
 	sudo -A apt-get update
-	sudo -A apt-get install -y ruby2.3
+	sudo -A apt-get install -y ruby2.7
 	sudo -A gem install gpsd_client
 	sudo -A gem install maidenhead
 	}

--- a/manage-pat-functions
+++ b/manage-pat-functions
@@ -121,35 +121,33 @@ fi
 GPSGRID(){
 CONFIG=$HOME/.config/pat/config.json
 
-if ! hash ruby>/dev/null; then
-echo "Ruby Not found on system"
-yad --form --width=300 --text-align=center --center --title="Ruby not Found" --text-align=center \
+if ! hash python3>/dev/null; then
+echo "Python3 Not found on system"
+yad --form --width=300 --text-align=center --center --title="Python3 not Found" --text-align=center \
 --image $LOGO --window-icon=$LOGO --image-on-top --separator="|" --item-separator="|" \
---text="Ruby is needed to read GPS data but not found installed on your system. Would you like to install it now?" \
---button="Install Ruby":2 \
+--text="Python3 is needed to read GPS data but not found installed on your system. Would you like to install it now?" \
+--button="Install Python3":2 \
 --button="Cancel":1
 BUT=$?
 	if [ $BUT = 1 ]; then
 	$MAIN &
 	exit
 	elif [ $BUT = 2 ]; then
-	INSTALLRUBY(){
+	INSTALLPYTHON(){
 	sudo -A apt-get update
-	sudo -A apt-get install -y ruby3
-	sudo -A gem install gpsd_client
-	sudo -A gem install maidenhead
+	sudo -A apt-get install -y python3
 	}
-	INSTALLRUBY | yad --center --progress --pulsate --auto-close --no-buttons --text-align=center \
---text="Installing Ruby. This will take several minutes\r<b>DO NOT CLOSE THIS WINDOW</b>\rDoing so will abort the install."
+	INSTALLPYTHON | yad --center --progress --pulsate --auto-close --no-buttons --text-align=center \
+--text="Installing Python 3. This will take several minutes\r<b>DO NOT CLOSE THIS WINDOW</b>\rDoing so will abort the install."
 	fi
 fi
 
 yad --center --timeout=5 --timeout-indicator=top \
 --auto-close --no-buttons --text="Getting grid from GPS" &
 
-NEWGRID=$($MYPATH/getgrid | cut -b 1-6)
+NEWGRID=$(python3 $MYPATH/getgrid.py | cut -b 1-7)
 
-if [ "$NEWGRID" = 'JJ00aa' ]; then
+if [ "$NEWGRID" = 'NOFIX' ]; then
 NEWGRID="GPS READ ERROR or NO LOCK"
 yad --form --width=400 --text-align=center --center --title="GPS ERROR" --text-align=center \
 --image $LOGO --window-icon=$LOGO --image-on-top --separator="|" --item-separator="|" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+maidenhead==1.7.0
+

--- a/setup
+++ b/setup
@@ -16,6 +16,14 @@ fi
 if ! hash jq 2>/dev/null; then
 sudo -A apt install -y jq
 fi
+if ! hash python3 2>/dev/null; then
+sudo -A apt install -y python3
+fi
+if ! hash python3-pip 2>/dev/null; then
+sudo -A apt install -y python3-pip
+fi
+
+pip3 install -r $MYPATH/requirements.txt
 
 if [ -f $HOME/patmenu/config ]; then
 #get patmenu config file and copy to patmenu2


### PR DESCRIPTION
I noticed that jq was not call out as a dependency and if not installed, it failed silently and acted as if the grid square was not correctly set.  Added logic to check for jq and if not to install similar to the ruby logic already existing.

Additionally, ruby 2.3 is EOL with ruby 2.7 going EOL in about two months.  Bump the ruby version to ruby 3 which has been running fine on my evolve3. 